### PR TITLE
Add the support of unix_socket for mysql

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -29,15 +29,15 @@ twig:
 # Doctrine Configuration
 doctrine:
     dbal:
-        driver:   %database_driver%
-        host:     %database_host%
-        port:     %database_port%
-        dbname:   %database_name%
-        user:     %database_user%
-        password: %database_password%
-        charset:  UTF8
-        path:     %database_path%
-
+        driver:   		%database_driver%
+        host:     		%database_host%
+        port:     		%database_port%
+        dbname:   		%database_name%
+        user:     		%database_user%
+        password: 		%database_password%
+        charset:  		UTF8
+        path:     		%database_path%
+        unix_socket : 		%database_socket%
     orm:
         entity_managers:
             default:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -9,3 +9,4 @@ parameters:
 
     locale:            en
     secret:            ThisTokenIsNotSoSecretChangeIt
+    database_socket:   ~


### PR DESCRIPTION
I needed to access to my MySQL database through unix_socket. So I just add this option to the config. 
